### PR TITLE
dp - Added calendar & task preview after parsing syllabus. 

### DIFF
--- a/Plannr/Plannr/CalendarPreviewView.swift
+++ b/Plannr/Plannr/CalendarPreviewView.swift
@@ -1,0 +1,456 @@
+//
+//  CalendarPreviewView.swift
+//  Plannr
+//
+//  Created by divyani punj on 1/29/26.
+//
+
+import SwiftUI
+
+struct CalendarPreviewView: View {
+    let events: [CalendarEvent]
+    
+    var body: some View {
+        
+        ZStack {
+            Color.black.ignoresSafeArea()
+            
+            ScrollView{
+                VStack(alignment: .leading, spacing: 16) {
+                    Text("Your Calendar")
+                        .font(.title2)
+                        .fontWeight(.bold)
+                        .foregroundColor(.white)
+                        .padding(.horizontal)
+                    
+                    CalendarGridView(events: events)
+                        .padding(.horizontal)
+                    
+                    Text("Your Events")
+                        .font(.title2)
+                        .fontWeight(.bold)
+                        .foregroundColor(.white)
+                        .padding(.horizontal)
+                    
+                    Text("\(events.count) items found")
+                        .font(.subheadline)
+                        .foregroundColor(.gray)
+                        .padding(.horizontal)
+                    
+                    // Events list
+                    VStack(spacing: 12) {
+                        ForEach(events, id: \.title) { event in
+                            EventCard(event: event)
+                        }
+                    }
+                    .padding(.horizontal)
+                }
+                .padding(.top)
+            }
+        }
+    }
+    
+    // Color based on event type
+    func colorForType(_ type: String) -> Color {
+        switch type.lowercased() {
+        case "homework": return .blue
+        case "exam": return .red
+        case "quiz": return .orange
+        case "lab": return .green
+        default: return .gray
+        }
+    }
+}
+
+struct EventCard: View {
+    let event: CalendarEvent
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack{
+                // Title
+                Text(event.title)
+                    .font(.headline)
+                    .foregroundColor(.white)
+                
+                Spacer()
+                
+                Text(event.type.capitalized)
+                    .font(.caption)
+                    .fontWeight(.medium)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 4)
+                    .background(colorForType(event.type))
+                    .foregroundColor(.white)
+                    .cornerRadius(12)
+            }
+            
+            // Date
+            HStack(spacing: 6) {
+                Image(systemName: "calendar")
+                    .font(.caption)
+                    .foregroundColor(.gray)
+                Text(event.date)
+                    .font(.subheadline)
+                    .foregroundColor(.gray)
+            }
+            
+            // Description (if not empty)
+            if !event.description.isEmpty {
+                Text(event.description)
+                    .font(.caption)
+                    .foregroundColor(.gray)
+                    .lineLimit(2)
+            }
+        }
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.gray.opacity(0.15))
+        .cornerRadius(12)
+    }
+    
+    func colorForType(_ type: String) -> Color {
+        switch type.lowercased() {
+        case "homework": return .blue
+        case "exam": return .red
+        case "quiz": return .orange
+        case "lab": return .green
+        default: return .gray
+        }
+    }
+}
+
+struct CalendarGridView: View {
+    let events: [CalendarEvent]
+    @State private var isWeekly = true
+    
+    var body: some View {
+        VStack {
+            // Toggle
+            Picker("View", selection: $isWeekly) {
+                Text("Week").tag(true)
+                Text("Month").tag(false)
+            }
+            .pickerStyle(.segmented)
+            .padding()
+            .onAppear {
+                UISegmentedControl.appearance().setTitleTextAttributes(
+                    [.foregroundColor: UIColor.white],
+                    for: .normal)
+                UISegmentedControl.appearance().setTitleTextAttributes(
+                    [.foregroundColor: UIColor.darkGray],
+                    for: .selected)
+                UISegmentedControl.appearance().backgroundColor = UIColor.darkGray
+            }
+            
+            if isWeekly {
+                WeeklyCalendarView(events: events)
+            } else {
+                MonthlyCalendarView(events: events)
+            }
+        }
+    }
+}
+
+struct WeeklyCalendarView: View {
+    let events: [CalendarEvent]
+    @State private var selectedDate: Date = Date()
+    
+    private let calendar = Calendar.current
+    private let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter
+    }()
+    
+    var body: some View {
+        VStack(spacing: 16) {
+            // Week header with navigation
+            HStack {
+                Button(action: { moveWeek(-1) }) {
+                    Image(systemName: "chevron.left")
+                        .foregroundColor(.white)
+                }
+                
+                Spacer()
+                
+                Text(weekRangeText())
+                    .font(.headline)
+                    .foregroundColor(.white)
+                
+                Spacer()
+                
+                Button(action: { moveWeek(1) }) {
+                    Image(systemName: "chevron.right")
+                        .foregroundColor(.white)
+                }
+            }
+            .padding(.horizontal)
+            
+            // Days of the week
+            HStack(spacing: 4) {
+                ForEach(daysInWeek(), id: \.self) { date in
+                    DayColumn(
+                        date: date,
+                        events: eventsForDate(date),
+                        isSelected: calendar.isDate(date, inSameDayAs: selectedDate)
+                    ) {
+                        selectedDate = date
+                    }
+                }
+            }
+            .padding(.horizontal, 0)
+            
+            VStack(spacing: 12){
+                ForEach(eventsForDate(selectedDate), id: \.title){
+                    event in EventCard(event: event)
+                }
+            }
+        }
+        .padding(.vertical)
+        .background(Color.gray.opacity(0.1))
+        .cornerRadius(16)
+    }
+    
+    // MARK: - Helper functions for weekly view
+    
+    func daysInWeek() -> [Date] {
+        let startOfWeek = calendar.date(from: calendar.dateComponents([.yearForWeekOfYear, .weekOfYear], from: selectedDate))!
+        return (0..<7).compactMap { calendar.date(byAdding: .day, value: $0, to: startOfWeek) }
+    }
+    
+    func moveWeek(_ direction: Int) {
+        if let newDate = calendar.date(byAdding: .weekOfYear, value: direction, to: selectedDate) {
+            selectedDate = newDate
+        }
+    }
+    
+    func weekRangeText() -> String {
+        let days = daysInWeek()
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMM d"
+        guard let first = days.first, let last = days.last else { return "" }
+        return "\(formatter.string(from: first)) - \(formatter.string(from: last))"
+    }
+    
+    func eventsForDate(_ date: Date) -> [CalendarEvent] {
+        let dateString = dateFormatter.string(from: date)
+        return events.filter { $0.date == dateString }
+    }
+}
+
+struct DayColumn: View {
+    let date: Date
+    let events: [CalendarEvent]
+    let isSelected: Bool
+    let onTap: () -> Void
+    
+    private let calendar = Calendar.current
+    
+    var body: some View {
+        VStack(spacing: 6) {
+            // Day name
+            Text(dayName())
+                .font(.caption2)
+                .foregroundColor(.gray)
+            
+            // Day number
+            Text("\(calendar.component(.day, from: date))")
+                .font(.system(size: 16, weight: isSelected ? .bold : .regular))
+                .foregroundColor(isSelected ? .blue : .white)
+                .frame(width: 32, height: 32)
+                .background(isSelected ? Color.blue.opacity(0.2) : Color.clear)
+                .cornerRadius(8)
+            
+            // Event dots
+            if !events.isEmpty {
+                HStack(spacing: 2) {
+                    ForEach(events.prefix(3), id: \.title) { event in
+                        Circle()
+                            .fill(colorForType(event.type))
+                            .frame(width: 6, height: 6)
+                    }
+                }
+            } else {
+                // Placeholder to keep alignment
+                Circle()
+                    .fill(Color.clear)
+                    .frame(width: 6, height: 6)
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 8)
+        .background(isSelected ? Color.white.opacity(0.05) : Color.clear)
+        .cornerRadius(8)
+        .onTapGesture { onTap() }
+    }
+    
+    func dayName() -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "EEE"
+        return formatter.string(from: date).uppercased()
+    }
+    
+    func colorForType(_ type: String) -> Color {
+        switch type.lowercased() {
+        case "homework": return .blue
+        case "exam": return .red
+        case "quiz": return .orange
+        case "lab": return .green
+        default: return .gray
+        }
+    }
+}
+
+struct MonthlyCalendarView: View {
+    let events: [CalendarEvent]
+    @State private var selectedDate: Date = Date()
+    
+    private let calendar = Calendar.current
+    private let columns = Array(repeating: GridItem(.flexible(), spacing: 4), count: 7)
+    private let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter
+    }()
+    
+    var body: some View {
+        VStack(spacing: 16) {
+            // Month header with navigation
+            HStack {
+                Button(action: { moveMonth(-1) }) {
+                    Image(systemName: "chevron.left")
+                        .foregroundColor(.white)
+                }
+                
+                Spacer()
+                
+                Text(monthYearText())
+                    .font(.headline)
+                    .foregroundColor(.white)
+                
+                Spacer()
+                
+                Button(action: { moveMonth(1) }) {
+                    Image(systemName: "chevron.right")
+                        .foregroundColor(.white)
+                }
+            }
+            .padding(.horizontal)
+            
+            // Day labels
+            HStack {
+                ForEach(["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"], id: \.self) { day in
+                    Text(day)
+                        .font(.caption2)
+                        .foregroundColor(.gray)
+                        .frame(maxWidth: .infinity)
+                }
+            }
+            
+            // Calendar grid
+            LazyVGrid(columns: columns, spacing: 8) {
+                ForEach(0..<startingWeekday(), id: \.self) { _ in
+                    Text("")
+                        .frame(height: 40)
+                }
+                
+                // Day cells
+                ForEach(daysInMonth(), id: \.self) { date in
+                    DayCell(
+                        date: date,
+                        events: eventsForDate(date),
+                        isSelected: calendar.isDate(date, inSameDayAs: selectedDate)
+                    ) {
+                        selectedDate = date
+                    }
+                }
+            }
+            .padding(.horizontal, 0)
+            
+            VStack(spacing: 12){
+                ForEach(eventsForDate(selectedDate), id: \.title){
+                    event in EventCard(event: event)
+                }
+            }
+        }
+        .padding(.vertical)
+        .background(Color.gray.opacity(0.1))
+        .cornerRadius(16)
+    }
+    
+    
+    // MARK: - Helper functions for monthly view
+    
+    func daysInMonth() -> [Date] {
+        let startOfMonth = calendar.date(from: calendar.dateComponents([.year, .month], from: selectedDate))!
+        let range = calendar.range(of: .day, in: .month, for: selectedDate)!
+        return (0..<range.count).compactMap { calendar.date(byAdding: .day, value: $0, to: startOfMonth) }
+    }
+    
+    func startingWeekday() -> Int {
+        let startOfMonth = calendar.date(from: calendar.dateComponents([.year, .month], from: selectedDate))!
+        return calendar.component(.weekday, from: startOfMonth) - 1  // 0 = Sunday
+    }
+    
+    func moveMonth(_ direction: Int) {
+        if let newDate = calendar.date(byAdding: .month, value: direction, to: selectedDate) {
+            selectedDate = newDate
+        }
+    }
+    
+    func monthYearText() -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMMM yyyy"
+        return formatter.string(from: selectedDate)
+    }
+    
+    func eventsForDate(_ date: Date) -> [CalendarEvent] {
+        let dateString = dateFormatter.string(from: date)
+        return events.filter { $0.date == dateString }
+    }
+}
+
+struct DayCell: View {
+    let date: Date
+    let events: [CalendarEvent]
+    let isSelected: Bool
+    let onTap: () -> Void
+    
+    private let calendar = Calendar.current
+    
+    var body: some View {
+        VStack(spacing: 2) {
+            Text("\(calendar.component(.day, from: date))")
+                .font(.system(size: 14, weight: isSelected ? .bold : .regular))
+                .foregroundColor(isSelected ? .blue : .white)
+            
+            // Event dot
+            if !events.isEmpty {
+                Circle()
+                    .fill(colorForType(events.first?.type ?? ""))
+                    .frame(width: 5, height: 5)
+            }
+        }
+        .frame(height: 40)
+        .frame(maxWidth: .infinity)
+        .background(isSelected ? Color.blue.opacity(0.2) : Color.clear)
+        .cornerRadius(8)
+        .onTapGesture { onTap() }
+    }
+    
+    func colorForType(_ type: String) -> Color {
+        switch type.lowercased() {
+        case "homework": return .blue
+        case "exam": return .red
+        case "quiz": return .orange
+        case "lab": return .green
+        default: return .gray
+        }
+    }
+}
+
+
+#Preview {
+    CalendarPreviewView(events: EventFixtures.sampleEvents)
+}

--- a/Plannr/Plannr/EventFixtures.swift
+++ b/Plannr/Plannr/EventFixtures.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+// Backend returns events in the following format:
+//"events": [
+//    {
+//        "title": "event name",
+//        "date": "YYYY-MM-DD",
+//        "type": "homework/exam/quiz/lab/other",
+//        "description": "brief description"
+//    }
+//]
+
+struct EventFixtures {
+    static let sampleEvents: [CalendarEvent] = [
+        CalendarEvent(title: "HW1", date: "2026-02-15", type: "homework", description: "Chapter 1 problems"),
+        CalendarEvent(title: "Midterm 1", date: "2026-02-20", type: "exam", description: "Covers weeks 1-4"),
+        CalendarEvent(title: "Lab 2", date: "2026-02-22", type: "lab", description: "Data structures lab"),
+        CalendarEvent(title: "Quiz 3", date: "2026-02-25", type: "quiz", description: "Weekly quiz")
+    ]
+}

--- a/Plannr/Plannr/PDFUploadView.swift
+++ b/Plannr/Plannr/PDFUploadView.swift
@@ -19,138 +19,144 @@ struct PDFUploadView: View {
     @State private var isUploading = false
     @State private var uploadError: String?
     @State private var parsedEvents: [CalendarEvent] = []
+    @State private var navigateToPreview = false
 
     var body: some View {
-        ZStack {
-            Color.black
-                .ignoresSafeArea(.all)
-            
-            VStack(spacing: 20) {
-                // header
-                Text("Let's organize your course schedules")
-                    .font(.headline)
-                    .foregroundColor(.white)
+        NavigationStack{
+            ZStack {
+                Color.black
+                    .ignoresSafeArea(.all)
                 
-                // upload button
-                Button(action: {
-                    showDocumentPicker = true
-                }) {
-                    HStack {
-                        Image(systemName: "doc.fill")
-                        Text("Upload PDF")
-                    }
-                    .padding()
-                    .background(Color.blue)
-                    .foregroundColor(.white)
-                    .cornerRadius(10)
-                }
-                .disabled(isUploading)
-
-                // display selected file name
-                Text(pdfFileName)
-                    .font(.caption)
-                    .foregroundColor(.gray)
-                    .padding(.horizontal)
-
-                // loading indicator
-                if isUploading {
-                    ProgressView("Uploading...")
-                        .tint(.blue)
-                }
-
-                // error message
-                if let error = uploadError {
-                    Text(error)
-                        .font(.caption)
-                        .foregroundColor(.red)
-                        .padding()
-                        .background(Color.red.opacity(0.1))
-                        .cornerRadius(8)
-                }
-
-                // display parsed events
-                if !parsedEvents.isEmpty {
-                    VStack(alignment: .leading, spacing: 12) {
-                        Text("Parsed Events")
-                            .font(.headline)
-                            .foregroundColor(.white)
-                            .padding(.horizontal)
-
-                        ScrollView {
-                            VStack(alignment: .leading, spacing: 12) {
-                                ForEach(parsedEvents, id: \.title) { event in
-                                    VStack(alignment: .leading, spacing: 6) {
-                                        Text(event.title)
-                                            .font(.subheadline)
-                                            .fontWeight(.semibold)
-                                            .foregroundColor(.white)
-
-                                        HStack(spacing: 10) {
-                                            Image(systemName: "calendar")
-                                                .font(.caption)
-                                                .foregroundColor(.blue)
-
-                                            Text(event.date)
-                                                .font(.caption)
-                                                .foregroundColor(.gray)
-                                        }
-
-                                        HStack(spacing: 8) {
-                                            Text(event.type)
-                                                .font(.caption2)
-                                                .fontWeight(.medium)
-                                                .padding(6)
-                                                .background(Color.blue.opacity(0.3))
-                                                .foregroundColor(.blue)
-                                                .cornerRadius(4)
-                                        }
-
-                                        if !event.description.isEmpty {
-                                            Text(event.description)
-                                                .font(.caption)
-                                                .foregroundColor(.gray)
-                                                .lineLimit(2)
-                                        }
-                                    }
-                                    .padding(.vertical, 12)
-                                    .padding(.horizontal)
-                                    .background(Color.gray.opacity(0.15))
-                                    .cornerRadius(10)
-                                }
-                            }
-                            .padding(.horizontal)
+                VStack(spacing: 20) {
+                    // header
+                    Text("Let's organize your course schedules")
+                        .font(.headline)
+                        .foregroundColor(.white)
+                    
+                    // upload button
+                    Button(action: {
+                        showDocumentPicker = true
+                    }) {
+                        HStack {
+                            Image(systemName: "doc.fill")
+                            Text("Upload PDF")
                         }
+                        .padding()
+                        .background(Color.blue)
+                        .foregroundColor(.white)
+                        .cornerRadius(10)
                     }
-                    .frame(maxHeight: 400)
-                    .padding()
-                    .background(Color.gray.opacity(0.08))
-                    .cornerRadius(12)
+                    .disabled(isUploading)
+                    
+                    // display selected file name
+                    Text(pdfFileName)
+                        .font(.caption)
+                        .foregroundColor(.gray)
+                        .padding(.horizontal)
+                    
+                    // loading indicator
+                    if isUploading {
+                        ProgressView("Uploading...")
+                            .tint(.blue)
+                    }
+                    
+                    // error message
+                    if let error = uploadError {
+                        Text(error)
+                            .font(.caption)
+                            .foregroundColor(.red)
+                            .padding()
+                            .background(Color.red.opacity(0.1))
+                            .cornerRadius(8)
+                    }
+                    
+                    // display parsed events
+                    if !parsedEvents.isEmpty {
+                        VStack(alignment: .leading, spacing: 12) {
+                            Text("Parsed Events")
+                                .font(.headline)
+                                .foregroundColor(.white)
+                                .padding(.horizontal)
+                            
+                            ScrollView {
+                                VStack(alignment: .leading, spacing: 12) {
+                                    ForEach(parsedEvents, id: \.title) { event in
+                                        VStack(alignment: .leading, spacing: 6) {
+                                            Text(event.title)
+                                                .font(.subheadline)
+                                                .fontWeight(.semibold)
+                                                .foregroundColor(.white)
+                                            
+                                            HStack(spacing: 10) {
+                                                Image(systemName: "calendar")
+                                                    .font(.caption)
+                                                    .foregroundColor(.blue)
+                                                
+                                                Text(event.date)
+                                                    .font(.caption)
+                                                    .foregroundColor(.gray)
+                                            }
+                                            
+                                            HStack(spacing: 8) {
+                                                Text(event.type)
+                                                    .font(.caption2)
+                                                    .fontWeight(.medium)
+                                                    .padding(6)
+                                                    .background(Color.blue.opacity(0.3))
+                                                    .foregroundColor(.blue)
+                                                    .cornerRadius(4)
+                                            }
+                                            
+                                            if !event.description.isEmpty {
+                                                Text(event.description)
+                                                    .font(.caption)
+                                                    .foregroundColor(.gray)
+                                                    .lineLimit(2)
+                                            }
+                                        }
+                                        .padding(.vertical, 12)
+                                        .padding(.horizontal)
+                                        .background(Color.gray.opacity(0.15))
+                                        .cornerRadius(10)
+                                    }
+                                }
+                                .padding(.horizontal)
+                            }
+                        }
+                        .frame(maxHeight: 400)
+                        .padding()
+                        .background(Color.gray.opacity(0.08))
+                        .cornerRadius(12)
+                    }
+                    
+                    Spacer()
                 }
-
-                Spacer()
+                .padding()
+                .fileImporter(
+                    isPresented: $showDocumentPicker,
+                    allowedContentTypes: [.pdf],
+                    allowsMultipleSelection: false
+                ) { result in
+                    switch result {
+                    case .success(let urls):
+                        guard let url = urls.first else { return }
+                        pdfURL = url
+                        pdfFileName = url.lastPathComponent
+                        
+                        // start accessing the security-scoped resource
+                        if url.startAccessingSecurityScopedResource() {
+                            // process and upload PDF (security scope is kept alive during upload)
+                            uploadPDF(url: url)
+                        }
+                        
+                    case .failure(let error):
+                        print("Error selecting file: \(error.localizedDescription)")
+                        uploadError = "Error selecting file: \(error.localizedDescription)"
+                    }
+                }
             }
-            .padding()
-            .fileImporter(
-                isPresented: $showDocumentPicker,
-                allowedContentTypes: [.pdf],
-                allowsMultipleSelection: false
-            ) { result in
-                switch result {
-                case .success(let urls):
-                    guard let url = urls.first else { return }
-                    pdfURL = url
-                    pdfFileName = url.lastPathComponent
-
-                    // start accessing the security-scoped resource
-                    if url.startAccessingSecurityScopedResource() {
-                        // process and upload PDF (security scope is kept alive during upload)
-                        uploadPDF(url: url)
-                    }
-
-                case .failure(let error):
-                    print("Error selecting file: \(error.localizedDescription)")
-                    uploadError = "Error selecting file: \(error.localizedDescription)"
-                }
+            .navigationDestination(isPresented: $navigateToPreview) {
+                CalendarPreviewView(events: parsedEvents)
             }
         }
     }
@@ -198,6 +204,7 @@ struct PDFUploadView: View {
                             DispatchQueue.main.async {
                                 self.parsedEvents = jsonResponse.events
                                 self.isUploading = false
+                                self.navigateToPreview = true
                             }
                         } else {
                             DispatchQueue.main.async {


### PR DESCRIPTION
Closes #69 

This PR: 
- adds CalendarPreviewView which shows a preview of the calendar (weekly and monthly view) from the parsed syllabus.
- edits PDFUploadView to pass parsedEvents to CalendarPreviewView. 
- adds a fixtures file to mock the response to "POST /syllabus HTTP/1.1". It's not necessary for the application to function, but it can be used to preview how pages will look without having to call the backend which can be useful for development on the frontend. 

**Demo**: https://drive.google.com/file/d/17hALFOxNw-3ps7tOErGXh3OTCn9DjfSn/view?usp=sharing
If you want to demo the app yourself you need your own OAuth credentials and gemini API key! 

**Note**: Used Claude to help learn Swift, help write some components, and debug.
