### PR TITLE
yj - auto-deployment script fixed

### DIFF
--- a/.github/workflows/CD.yaml
+++ b/.github/workflows/CD.yaml
@@ -15,4 +15,6 @@ jobs:
           username: ${{ vars.SSH_USERNAME }}
           key: ${{ secrets.SSH_KEY }}
           script: |
+            cd /home/bitnami/pj07-syllabus-to-cal-2pm
+            git pull origin main
             sudo systemctl restart plannr


### PR DESCRIPTION
The old script only restart the service.
Add "git pull origin main" command upon every push to the main branch on github.
I hope it would run normally this time.