### PR TITLE
as - Error Message for non-syllabus

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -215,7 +215,7 @@ async def parse_with_gemini(syllabus_text: str) -> dict:
 Your primary objective is **correct due-date inference**, even when dates are implicit, relative, or described indirectly.
 
 Firstly, ensure the uploaded document is a syllabus for a university course. If it does not appear to be a syllabus, respond with an error message stating such in the JSON output.
-
+Make this output as a JSON object with an "error" field if it's not a syllabus, or an "events" field if it is. Do NOT attempt to extract events if the document is not a syllabus.
 ---
 
 ## Step 1: Academic Term & Year Inference (MANDATORY)


### PR DESCRIPTION
Fixes #95 

## Acceptance Tests
### Test 1 - Syllabus Uploaded 
Given a university course syllabus (PDF or text)
When it is uploaded
Then the system returns a JSON object with an "events" field
And "error" is not present

### Non-syllabus document
Given a document that is not a course syllabus (resume, article, notes, random PDF)
When it is uploaded
Then the system returns a JSON object with an "error" field
And "events" is not present
And no calendar events are generated