### PR TITLE
dp - Added an error message for non-syllabus file upload.

### DIFF
--- a/Plannr/Plannr/PDFUploadView.swift
+++ b/Plannr/Plannr/PDFUploadView.swift
@@ -220,6 +220,7 @@ struct CalendarEvent: Codable, Identifiable {
     var description: String
     var colorHex: String = "007AFF"
     var status: EventStatus = .pending
+    var isSyllabus: Bool = true
 
     var color: Color {
         get { Color(hex: colorHex) }
@@ -227,7 +228,7 @@ struct CalendarEvent: Codable, Identifiable {
     }
 
     enum CodingKeys: String, CodingKey {
-        case id, title, date, type, description, colorHex, status
+        case id, title, date, type, description, colorHex, status, isSyllabus
     }
 
     init(title: String, date: String, type: String, description: String) {
@@ -247,6 +248,7 @@ struct CalendarEvent: Codable, Identifiable {
         description = try container.decode(String.self, forKey: .description)
         colorHex = try container.decodeIfPresent(String.self, forKey: .colorHex) ?? "007AFF"
         status = try container.decodeIfPresent(EventStatus.self, forKey: .status) ?? .pending
+        isSyllabus = try container.decodeIfPresent(Bool.self, forKey: .isSyllabus) ?? true
     }
 }
 

--- a/Plannr/Plannr/SyllabusUploadView.swift
+++ b/Plannr/Plannr/SyllabusUploadView.swift
@@ -261,6 +261,12 @@ struct SyllabusUploadView: View {
                         )
                         
                         DispatchQueue.main.async {
+                            let notSyllabus = jsonResponse.events.contains { $0.isSyllabus == false }
+                            if jsonResponse.events.isEmpty || notSyllabus{
+                                self.uploadError = "No events were found. Please ensure you are uploading a valid course syllabus and try again."
+                                self.isUploading = false
+                                return
+                            }
                             self.parsedEvents = jsonResponse.events
                             self.isUploading = false
                             self.navigateToPreview = true


### PR DESCRIPTION
Closes #93 

This PR: 
- Adds an error message for non-syllabus file (includes files with no events detected) uploads.  
<img width="496" height="987" alt="Screenshot 2026-02-19 at 3 13 19 AM" src="https://github.com/user-attachments/assets/bb958ad9-0e20-4efd-b3ea-5ce0f0892eb9" />
