### PR TITLE
AK - Added Text Entry Option

### DIFF
--- a/Plannr/Plannr/SyllabusUploadView.swift
+++ b/Plannr/Plannr/SyllabusUploadView.swift
@@ -499,10 +499,34 @@ struct ImagePicker: UIViewControllerRepresentable {
         init(onImagesPicked: @escaping ([UIImage]) -> Void) {
             self.onImagesPicked = onImagesPicked
         }
+
+        func picker(
+            _ picker: PHPickerViewController,
+            didFinishPicking results: [PHPickerResult]
+        ) {
+            picker.dismiss(animated: true)
+
+            var images: [UIImage] = []
+            let dispatchGroup = DispatchGroup()
+
+            for result in results {
+                if result.itemProvider.canLoadObject(ofClass: UIImage.self) {
+                    dispatchGroup.enter()
+                    result.itemProvider.loadObject(ofClass: UIImage.self) { object, _ in
+                        if let image = object as? UIImage {
+                            images.append(image)
+                        }
+                        dispatchGroup.leave()
                     }
                 }
             }
 
+            dispatchGroup.notify(queue: .main) {
+                self.onImagesPicked(images)
+            }
+        }
+    }
+}
 
 struct TextEntryView: View {
     @Environment(\.dismiss) var dismiss
@@ -539,31 +563,7 @@ struct TextEntryView: View {
         }
     }
 }
-            didFinishPicking results: [PHPickerResult]
-        ) {
-            picker.dismiss(animated: true)
 
-            var images: [UIImage] = []
-            let dispatchGroup = DispatchGroup()
-
-            for result in results {
-                if result.itemProvider.canLoadObject(ofClass: UIImage.self) {
-                    dispatchGroup.enter()
-                    result.itemProvider.loadObject(ofClass: UIImage.self) { object, _ in
-                        if let image = object as? UIImage {
-                            images.append(image)
-                        }
-                        dispatchGroup.leave()
-                    }
-                }
-            }
-
-            dispatchGroup.notify(queue: .main) {
-                self.onImagesPicked(images)
-            }
-        }
-    }
-}
 
 #Preview {
     NavigationStack {


### PR DESCRIPTION
Closes #119 

https://github.com/user-attachments/assets/ef975536-d233-432d-8534-6164206c2b90

Acceptance Criteria:
Given the user enters or pastes syllabus text into the app
When the text is submitted for processing
Then the app converts the entered text into a PDF
And sends the generated PDF to Gemini for parsing
And displays the parsed syllabus information to the user