### PR TITLE
mb - Class Edit Flow + Google Calendar Sync Overhaul

### DIFF
--- a/Plannr/Plannr/CalendarPreviewView.swift
+++ b/Plannr/Plannr/CalendarPreviewView.swift
@@ -30,6 +30,7 @@ struct CalendarPreviewView: View {
     @State private var exportErrorMessage: String?
     @State private var showExportError = false
     @State private var sharedEventColor: Color
+    @State private var pendingSyncResponse: CalendarSyncResponse?
     
     init(className: String, classSchedule: String, classColor: Color, existingClassID: UUID, events: [CalendarEvent], onSyncComplete: (() -> Void)? = nil) {
         self.className = className
@@ -197,14 +198,33 @@ struct CalendarPreviewView: View {
             }
             .alert(syncSuccess == true ? "Sync Complete" : "Sync Failed", isPresented: $showSyncAlert) {
                 Button("OK", role: .cancel) {
-                    if syncSuccess == true {
+                    if syncSuccess == true, let syncResp = pendingSyncResponse {
+                        // Build lookup: localId → googleEventId
+                        let idMap = Dictionary(
+                            uniqueKeysWithValues: syncResp.syncedEvents.map { ($0.localId, $0.googleEventId) }
+                        )
+                        // Apply google event IDs to accepted events
+                        var acceptedEvents = events.filter { $0.status == .accepted }
+                        for i in acceptedEvents.indices {
+                            acceptedEvents[i].googleEventId = idMap[acceptedEvents[i].id.uuidString]
+                        }
+                        // Fetch existing class to preserve its id-based identity
+                        let existingColorHex = classManager.classes
+                            .first(where: { $0.id == existingClassID })?.colorHex
+                            ?? sharedEventColor.toHex()
                         classManager.removeClassByID(existingClassID)
                         classManager.addClass(Class(
+                            id: existingClassID,
                             name: className,
                             schedule: classSchedule,
-                            colorHex: sharedEventColor.toHex(),
-                            events: events.filter { $0.status == .accepted }
+                            colorHex: existingColorHex,
+                            events: acceptedEvents,
+                            status: .active,
+                            googleCalendarId: syncResp.googleCalendarId,
+                            lastSynced: Date(),
+                            hasUnsyncedChanges: false
                         ))
+                        pendingSyncResponse = nil
                         DispatchQueue.main.async {
                             onSyncComplete?()
                         }
@@ -324,7 +344,7 @@ struct CalendarPreviewView: View {
 
         guard let email = UserDefaults.standard.string(forKey: "userEmail"),
               let encodedEmail = email.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
-              let url = URL(string: "\(BACKEND_URL)/calendar?email=\(encodedEmail)") else {
+              let url = URL(string: "\(BACKEND_URL)calendar/sync?email=\(encodedEmail)") else {
             syncMessage = "Could not determine your account email. Please sign in again."
             syncSuccess = false
             showSyncAlert = true
@@ -333,16 +353,62 @@ struct CalendarPreviewView: View {
 
         isSyncing = true
 
-        struct SyncRequestBody: Encodable {
-            let events: [CalendarEvent]
+        // Fetch existing class so we can pass its google_calendar_id (if any)
+        let existingClass = classManager.classes.first(where: { $0.id == existingClassID })
+
+        struct SyncEventBody: Encodable {
+            let localId: String
+            let title: String
+            let date: String
+            let description: String
+            let type: String
+            let googleEventId: String?
+            let isDeleted: Bool
+
+            enum CodingKeys: String, CodingKey {
+                case localId = "local_id"
+                case title, date, description, type
+                case googleEventId = "google_event_id"
+                case isDeleted = "is_deleted"
+            }
         }
+
+        struct SyncRequestBody: Encodable {
+            let className: String
+            let googleCalendarId: String?
+            let events: [SyncEventBody]
+
+            enum CodingKeys: String, CodingKey {
+                case className = "class_name"
+                case googleCalendarId = "google_calendar_id"
+                case events
+            }
+        }
+
+        let eventBodies = acceptedEvents.map { ev in
+            SyncEventBody(
+                localId: ev.id.uuidString,
+                title: ev.title,
+                date: ev.date,
+                description: ev.description,
+                type: ev.type,
+                googleEventId: ev.googleEventId,
+                isDeleted: false
+            )
+        }
+
+        let body = SyncRequestBody(
+            className: className,
+            googleCalendarId: existingClass?.googleCalendarId,
+            events: eventBodies
+        )
 
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
         do {
-            request.httpBody = try JSONEncoder().encode(SyncRequestBody(events: acceptedEvents))
+            request.httpBody = try JSONEncoder().encode(body)
         } catch {
             isSyncing = false
             syncMessage = "Failed to encode events."
@@ -356,11 +422,14 @@ struct CalendarPreviewView: View {
                 let (data, response) = try await URLSession.shared.data(for: request)
                 await MainActor.run {
                     isSyncing = false
-                    if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 {
-                        syncMessage = "Successfully added \(acceptedEvents.count) events to your calendar!"
+                    if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200,
+                       let syncResp = try? JSONDecoder().decode(CalendarSyncResponse.self, from: data) {
+                        syncMessage = "Successfully synced \(acceptedEvents.count) events!"
                         syncSuccess = true
-                    } else if let body = try? JSONDecoder().decode([String: String].self, from: data),
-                              let errorMsg = body["error"] ?? body["detail"] {
+                        // Store google IDs and calendar ID so the alert handler can use them
+                        pendingSyncResponse = syncResp
+                    } else if let errBody = try? JSONDecoder().decode([String: String].self, from: data),
+                              let errorMsg = errBody["error"] ?? errBody["detail"] {
                         syncMessage = errorMsg
                         syncSuccess = false
                     } else {
@@ -378,6 +447,28 @@ struct CalendarPreviewView: View {
                 }
             }
         }
+    }
+}
+
+// MARK: - Sync response model
+
+struct CalendarSyncResponse: Decodable {
+    let googleCalendarId: String
+    let syncedEvents: [SyncedEventMapping]
+
+    enum CodingKeys: String, CodingKey {
+        case googleCalendarId = "google_calendar_id"
+        case syncedEvents = "synced_events"
+    }
+}
+
+struct SyncedEventMapping: Decodable {
+    let localId: String
+    let googleEventId: String
+
+    enum CodingKeys: String, CodingKey {
+        case localId = "local_id"
+        case googleEventId = "google_event_id"
     }
 }
 

--- a/Plannr/Plannr/ClassEditView.swift
+++ b/Plannr/Plannr/ClassEditView.swift
@@ -1,0 +1,566 @@
+//
+//  ClassEditView.swift
+//  Plannr
+//
+
+import SwiftUI
+
+// MARK: - Sync response models
+
+private struct ClassSyncResponse: Decodable {
+    let googleCalendarId: String
+    let syncedEvents: [SyncedEventEntry]
+
+    private enum CodingKeys: String, CodingKey {
+        case googleCalendarId = "google_calendar_id"
+        case syncedEvents = "synced_events"
+    }
+}
+
+private struct SyncedEventEntry: Decodable {
+    let localId: String
+    let googleEventId: String
+
+    private enum CodingKeys: String, CodingKey {
+        case localId = "local_id"
+        case googleEventId = "google_event_id"
+    }
+}
+
+// MARK: - ClassEditView
+
+struct ClassEditView: View {
+    @EnvironmentObject var classManager: ClassManager
+    @EnvironmentObject var authManager: AuthManager
+    @Environment(\.dismiss) private var dismiss
+
+    // Local mutable copy of the class
+    @State private var editableClass: Class
+    @State private var editingEvent: CalendarEvent?
+    @State private var isSyncing = false
+    @State private var syncErrorMessage: String?
+    @State private var showSyncError = false
+    @State private var navigateToUpload = false
+
+    var onSyncComplete: (() -> Void)?
+
+    init(cls: Class, onSyncComplete: (() -> Void)? = nil) {
+        _editableClass = State(initialValue: cls)
+        self.onSyncComplete = onSyncComplete
+    }
+
+    // Events visible in the list (exclude soft-deleted)
+    private var visibleEvents: [CalendarEvent] {
+        editableClass.events.filter { !$0.isDeletedLocally }
+    }
+
+    // Count of changes pending a re-sync
+    private var unsyncedCount: Int {
+        editableClass.events.filter { $0.isEdited || $0.isDeletedLocally || $0.googleEventId == nil }.count
+    }
+
+    var body: some View {
+        ZStack {
+            Color.black.ignoresSafeArea()
+
+            VStack(spacing: 0) {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 20) {
+
+                        // ── Header ────────────────────────────────────────
+                        classHeader
+
+                        // ── Events list ───────────────────────────────────
+                        eventsSection
+                    }
+                    .padding(.top, 20)
+                    .padding(.bottom, 100) // leave room for the sticky button
+                }
+
+                // ── Sticky bottom button ───────────────────────────────
+                bottomButton
+            }
+        }
+        .navigationTitle(editableClass.name)
+        .navigationBarTitleDisplayMode(.inline)
+        .sheet(item: $editingEvent) { event in
+            EventEditView(event: event) { updatedEvent in
+                applyEventEdit(updatedEvent)
+                editingEvent = nil
+            }
+        }
+        .navigationDestination(isPresented: $navigateToUpload) {
+            SyllabusUploadView(
+                className: editableClass.name,
+                classSchedule: editableClass.schedule,
+                classColor: editableClass.color,
+                existingClassID: editableClass.id,
+                existingEvents: editableClass.events,
+                onSyncComplete: {
+                    // Reload class from classManager to pick up new events + status
+                    if let updated = classManager.classes.first(where: { $0.id == editableClass.id }) {
+                        editableClass = updated
+                    }
+                }
+            )
+            .environmentObject(classManager)
+            .environmentObject(authManager)
+        }
+        .alert("Sync Failed", isPresented: $showSyncError) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(syncErrorMessage ?? "An unknown error occurred.")
+        }
+        .onAppear {
+            // Refresh from classManager in case another view updated it
+            if let latest = classManager.classes.first(where: { $0.id == editableClass.id }) {
+                editableClass = latest
+            }
+        }
+    }
+
+    // MARK: - Header
+
+    private var classHeader: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .top) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(editableClass.name)
+                        .font(.title2)
+                        .fontWeight(.bold)
+                        .foregroundColor(.white)
+
+                    if !editableClass.schedule.isEmpty {
+                        HStack(spacing: 4) {
+                            Image(systemName: "calendar")
+                                .font(.caption)
+                            Text(editableClass.schedule)
+                                .font(.caption)
+                        }
+                        .foregroundColor(.gray)
+                    }
+                }
+
+                Spacer()
+
+                // Status picker (ACTIVE / INACTIVE only; NO_SYLLABUS is read-only)
+                if editableClass.status == .noSyllabus {
+                    Text("NO SYLLABUS")
+                        .font(.caption2)
+                        .fontWeight(.bold)
+                        .foregroundColor(.orange)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 6)
+                        .background(Color.orange.opacity(0.2))
+                        .cornerRadius(8)
+                } else {
+                    Menu {
+                        Button("ACTIVE") {
+                            editableClass.status = .active
+                            persistClass()
+                        }
+                        Button("INACTIVE") {
+                            editableClass.status = .inactive
+                            persistClass()
+                        }
+                    } label: {
+                        HStack(spacing: 4) {
+                            Text(editableClass.status == .active ? "ACTIVE" : "INACTIVE")
+                                .font(.caption2)
+                                .fontWeight(.bold)
+                            Image(systemName: "chevron.down")
+                                .font(.caption2)
+                        }
+                        .foregroundColor(editableClass.status == .active ? editableClass.color : .gray)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 6)
+                        .background(
+                            (editableClass.status == .active ? editableClass.color : Color.gray).opacity(0.2)
+                        )
+                        .cornerRadius(8)
+                    }
+                }
+            }
+
+            // Color picker
+            ColorPicker(selection: Binding(
+                get: { editableClass.color },
+                set: { newColor in
+                    editableClass.colorHex = newColor.toHex()
+                    persistClass()
+                }
+            ), supportsOpacity: false) {
+                Text("Color")
+                    .font(.caption)
+                    .foregroundColor(.gray)
+            }
+
+            // Last synced
+            if let lastSynced = editableClass.lastSynced {
+                Text("Last synced: \(lastSynced.formatted(date: .abbreviated, time: .shortened))")
+                    .font(.caption2)
+                    .foregroundColor(.gray)
+            }
+        }
+        .padding(.horizontal)
+    }
+
+    // MARK: - Events section
+
+    private var eventsSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text("Events (\(visibleEvents.count))")
+                    .font(.headline)
+                    .fontWeight(.bold)
+                    .foregroundColor(.white)
+                Spacer()
+            }
+            .padding(.horizontal)
+
+            if visibleEvents.isEmpty {
+                Text("No events yet. Upload a PDF to get started.")
+                    .font(.subheadline)
+                    .foregroundColor(.gray)
+                    .padding(.horizontal)
+            } else {
+                ForEach(visibleEvents) { event in
+                    ClassEventRow(event: event, classColor: editableClass.color) {
+                        editingEvent = event
+                    } onDelete: {
+                        softDeleteEvent(event)
+                    }
+                    .padding(.horizontal)
+                }
+            }
+        }
+    }
+
+    // MARK: - Bottom button
+
+    private var bottomButton: some View {
+        Group {
+            if authManager.isGuest {
+                HStack(spacing: 8) {
+                    Image(systemName: "lock.fill")
+                    Text("Sign in to sync to Google Calendar")
+                        .font(.headline)
+                }
+                .foregroundColor(.white.opacity(0.5))
+                .frame(maxWidth: .infinity)
+                .padding()
+                .background(Color.gray.opacity(0.3))
+                .cornerRadius(12)
+                .padding(.horizontal)
+                .padding(.vertical, 12)
+                .background(Color.black)
+            } else if editableClass.hasUnsyncedChanges {
+                Button(action: { Task { await resyncChanges() } }) {
+                    HStack(spacing: 8) {
+                        if isSyncing {
+                            ProgressView().tint(.white)
+                        }
+                        Text(isSyncing ? "Syncing..." : "Re-sync (\(unsyncedCount)) Changes")
+                            .font(.headline)
+                            .foregroundColor(.white)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(isSyncing ? Color.gray : Color.blue)
+                    .cornerRadius(12)
+                }
+                .disabled(isSyncing)
+                .padding(.horizontal)
+                .padding(.vertical, 12)
+                .background(Color.black)
+            } else {
+                Button(action: { navigateToUpload = true }) {
+                    HStack(spacing: 8) {
+                        Image(systemName: "arrow.up.doc.fill")
+                        Text("Upload New PDF")
+                            .font(.headline)
+                    }
+                    .foregroundColor(.white)
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(Color.blue)
+                    .cornerRadius(12)
+                }
+                .padding(.horizontal)
+                .padding(.vertical, 12)
+                .background(Color.black)
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func applyEventEdit(_ updated: CalendarEvent) {
+        guard let idx = editableClass.events.firstIndex(where: { $0.id == updated.id }) else { return }
+        var mutated = updated
+        mutated.isEdited = true
+        editableClass.events[idx] = mutated
+        editableClass.hasUnsyncedChanges = true
+        persistClass()
+    }
+
+    private func softDeleteEvent(_ event: CalendarEvent) {
+        guard let idx = editableClass.events.firstIndex(where: { $0.id == event.id }) else { return }
+        editableClass.events[idx].isDeletedLocally = true
+        editableClass.hasUnsyncedChanges = true
+        persistClass()
+    }
+
+    private func persistClass() {
+        classManager.updateClass(editableClass)
+    }
+
+    // MARK: - Re-sync
+
+    private func resyncChanges() async {
+        guard let email = UserDefaults.standard.string(forKey: "userEmail"),
+              let encodedEmail = email.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
+              let url = URL(string: "\(BACKEND_URL)calendar/sync?email=\(encodedEmail)") else {
+            syncErrorMessage = "Could not determine your account email."
+            showSyncError = true
+            return
+        }
+
+        await MainActor.run { isSyncing = true }
+
+        // Build request body
+        struct SyncEventBody: Encodable {
+            let localId: String
+            let title: String
+            let date: String
+            let description: String
+            let type: String
+            let googleEventId: String?
+            let isDeleted: Bool
+
+            enum CodingKeys: String, CodingKey {
+                case localId = "local_id"
+                case title, date, description, type
+                case googleEventId = "google_event_id"
+                case isDeleted = "is_deleted"
+            }
+        }
+
+        struct SyncRequestBody: Encodable {
+            let className: String
+            let googleCalendarId: String?
+            let events: [SyncEventBody]
+
+            enum CodingKeys: String, CodingKey {
+                case className = "class_name"
+                case googleCalendarId = "google_calendar_id"
+                case events
+            }
+        }
+
+        // Send all non-deleted events that need syncing + all deleted events
+        let eventsToSync: [SyncEventBody] = editableClass.events.compactMap { ev in
+            // Skip events that are deleted locally without a google ID (never synced, just drop them)
+            if ev.isDeletedLocally && ev.googleEventId == nil { return nil }
+            return SyncEventBody(
+                localId: ev.id.uuidString,
+                title: ev.title,
+                date: ev.date,
+                description: ev.description,
+                type: ev.type,
+                googleEventId: ev.googleEventId,
+                isDeleted: ev.isDeletedLocally
+            )
+        }
+
+        let body = SyncRequestBody(
+            className: editableClass.name,
+            googleCalendarId: editableClass.googleCalendarId,
+            events: eventsToSync
+        )
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        do {
+            request.httpBody = try JSONEncoder().encode(body)
+        } catch {
+            await MainActor.run {
+                isSyncing = false
+                syncErrorMessage = "Failed to encode sync request."
+                showSyncError = true
+            }
+            return
+        }
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            await MainActor.run {
+                isSyncing = false
+                if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200,
+                   let syncResponse = try? JSONDecoder().decode(ClassSyncResponse.self, from: data) {
+                    applySync(response: syncResponse)
+                } else if let errBody = try? JSONDecoder().decode([String: String].self, from: data),
+                          let errMsg = errBody["error"] {
+                    syncErrorMessage = errMsg
+                    showSyncError = true
+                } else {
+                    syncErrorMessage = "Re-sync failed. Please try again."
+                    showSyncError = true
+                }
+            }
+        } catch {
+            await MainActor.run {
+                isSyncing = false
+                syncErrorMessage = "Network error: \(error.localizedDescription)"
+                showSyncError = true
+            }
+        }
+    }
+
+    private func applySync(response: ClassSyncResponse) {
+        // Update calendar ID
+        editableClass.googleCalendarId = response.googleCalendarId
+
+        // Build lookup: localId → googleEventId
+        let idMap = Dictionary(uniqueKeysWithValues: response.syncedEvents.map { ($0.localId, $0.googleEventId) })
+
+        // Apply to events
+        for i in editableClass.events.indices {
+            let ev = editableClass.events[i]
+            if ev.isDeletedLocally {
+                // Will be removed below
+                continue
+            }
+            if let gid = idMap[ev.id.uuidString] {
+                editableClass.events[i].googleEventId = gid
+            }
+            editableClass.events[i].isEdited = false
+        }
+
+        // Remove soft-deleted events from local storage
+        editableClass.events.removeAll { $0.isDeletedLocally }
+
+        // Update class metadata
+        editableClass.hasUnsyncedChanges = false
+        editableClass.lastSynced = Date()
+        if editableClass.status == .noSyllabus {
+            editableClass.status = .active
+        }
+
+        persistClass()
+    }
+}
+
+// MARK: - ClassEventRow
+
+struct ClassEventRow: View {
+    let event: CalendarEvent
+    let classColor: Color
+    let onEdit: () -> Void
+    let onDelete: () -> Void
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            // Color bar
+            RoundedRectangle(cornerRadius: 2)
+                .fill(classColor)
+                .frame(width: 3)
+
+            VStack(alignment: .leading, spacing: 4) {
+                HStack {
+                    Text(event.title)
+                        .font(.subheadline)
+                        .fontWeight(.semibold)
+                        .foregroundColor(.white)
+
+                    Spacer()
+
+                    if event.isEdited {
+                        Text("EDITED")
+                            .font(.caption2)
+                            .fontWeight(.bold)
+                            .foregroundColor(.yellow)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 3)
+                            .background(Color.yellow.opacity(0.2))
+                            .cornerRadius(6)
+                    }
+
+                    Text(event.type.capitalized)
+                        .font(.caption2)
+                        .foregroundColor(.white.opacity(0.7))
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 3)
+                        .background(classColor.opacity(0.3))
+                        .cornerRadius(6)
+                }
+
+                HStack(spacing: 4) {
+                    Image(systemName: "calendar")
+                        .font(.caption2)
+                        .foregroundColor(.gray)
+                    Text(event.date)
+                        .font(.caption)
+                        .foregroundColor(.gray)
+                }
+
+                if !event.description.isEmpty {
+                    Text(event.description)
+                        .font(.caption)
+                        .foregroundColor(.gray)
+                        .lineLimit(2)
+                }
+
+                // Action buttons
+                HStack(spacing: 8) {
+                    Button(action: onEdit) {
+                        HStack(spacing: 4) {
+                            Image(systemName: "pencil").font(.caption2)
+                            Text("Edit").font(.caption2).fontWeight(.medium)
+                        }
+                        .foregroundColor(.white)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 5)
+                        .background(Color.blue.opacity(0.6))
+                        .cornerRadius(6)
+                    }
+
+                    Button(action: onDelete) {
+                        HStack(spacing: 4) {
+                            Image(systemName: "trash").font(.caption2)
+                            Text("Delete").font(.caption2).fontWeight(.medium)
+                        }
+                        .foregroundColor(.white)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 5)
+                        .background(Color.red.opacity(0.6))
+                        .cornerRadius(6)
+                    }
+                }
+                .padding(.top, 2)
+            }
+        }
+        .padding()
+        .background(Color.gray.opacity(0.12))
+        .cornerRadius(10)
+    }
+}
+
+#Preview {
+    NavigationStack {
+        ClassEditView(cls: Class(
+            name: "CS148",
+            schedule: "MWF 10:00 AM",
+            colorHex: "007AFF",
+            events: [
+                CalendarEvent(title: "HW1", date: "2026-03-15", type: "homework", description: "Chapter 1"),
+                CalendarEvent(title: "Midterm 1", date: "2026-03-20", type: "exam", description: "Covers weeks 1-4")
+            ],
+            status: .active
+        ))
+        .environmentObject(ClassManager())
+        .environmentObject(AuthManager())
+    }
+}

--- a/Plannr/Plannr/ClassManager.swift
+++ b/Plannr/Plannr/ClassManager.swift
@@ -8,6 +8,12 @@
 import Foundation
 import SwiftUI
 
+enum ClassStatus: String, Codable {
+    case noSyllabus = "NO_SYLLABUS"
+    case active     = "ACTIVE"
+    case inactive   = "INACTIVE"
+}
+
 class ClassManager: ObservableObject {
     @Published var classes: [Class] = []
 
@@ -60,32 +66,92 @@ class ClassManager: ObservableObject {
 
 // Class model
 struct Class: Identifiable, Codable, Hashable {
-    static func == (lhs: Class, rhs: Class) -> Bool { lhs.id == rhs.id }
-    func hash(into hasher: inout Hasher) { hasher.combine(id) }
+    static func == (lhs: Class, rhs: Class) -> Bool {
+        lhs.id == rhs.id
+            && lhs.colorHex == rhs.colorHex
+            && lhs.name == rhs.name
+            && lhs.schedule == rhs.schedule
+            && lhs.status == rhs.status
+            && lhs.hasUnsyncedChanges == rhs.hasUnsyncedChanges
+            && lhs.events.count == rhs.events.count
+    }
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+        hasher.combine(colorHex)
+        hasher.combine(status)
+    }
     let id: UUID
     var name: String
     var schedule: String
     var colorHex: String
     var events: [CalendarEvent]
-    
+    var status: ClassStatus
+    var googleCalendarId: String?
+    var lastSynced: Date?
+    var hasUnsyncedChanges: Bool
+
     var color: Color {
         get { Color(hex: colorHex) }
         set { colorHex = newValue.toHex() }
     }
-    
-    init(name: String, schedule: String = "", colorHex: String = "007AFF", events: [CalendarEvent] = []) {
+
+    enum CodingKeys: String, CodingKey {
+        case id, name, schedule, colorHex, events, status, googleCalendarId, lastSynced, hasUnsyncedChanges
+    }
+
+    init(
+        name: String,
+        schedule: String = "",
+        colorHex: String = "007AFF",
+        events: [CalendarEvent] = [],
+        status: ClassStatus = .noSyllabus,
+        googleCalendarId: String? = nil,
+        lastSynced: Date? = nil,
+        hasUnsyncedChanges: Bool = false
+    ) {
         self.id = UUID()
         self.name = name
         self.schedule = schedule
         self.colorHex = colorHex
         self.events = events
+        self.status = status
+        self.googleCalendarId = googleCalendarId
+        self.lastSynced = lastSynced
+        self.hasUnsyncedChanges = hasUnsyncedChanges
     }
 
-    init(id: UUID, name: String, schedule: String = "", colorHex: String = "007AFF", events: [CalendarEvent] = []) {
+    init(
+        id: UUID,
+        name: String,
+        schedule: String = "",
+        colorHex: String = "007AFF",
+        events: [CalendarEvent] = [],
+        status: ClassStatus = .noSyllabus,
+        googleCalendarId: String? = nil,
+        lastSynced: Date? = nil,
+        hasUnsyncedChanges: Bool = false
+    ) {
         self.id = id
         self.name = name
         self.schedule = schedule
         self.colorHex = colorHex
         self.events = events
+        self.status = status
+        self.googleCalendarId = googleCalendarId
+        self.lastSynced = lastSynced
+        self.hasUnsyncedChanges = hasUnsyncedChanges
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        name = try container.decode(String.self, forKey: .name)
+        schedule = try container.decodeIfPresent(String.self, forKey: .schedule) ?? ""
+        colorHex = try container.decodeIfPresent(String.self, forKey: .colorHex) ?? "007AFF"
+        events = try container.decodeIfPresent([CalendarEvent].self, forKey: .events) ?? []
+        status = try container.decodeIfPresent(ClassStatus.self, forKey: .status) ?? .noSyllabus
+        googleCalendarId = try container.decodeIfPresent(String.self, forKey: .googleCalendarId)
+        lastSynced = try container.decodeIfPresent(Date.self, forKey: .lastSynced)
+        hasUnsyncedChanges = try container.decodeIfPresent(Bool.self, forKey: .hasUnsyncedChanges) ?? false
     }
 }

--- a/Plannr/Plannr/PDFUploadView.swift
+++ b/Plannr/Plannr/PDFUploadView.swift
@@ -136,14 +136,9 @@ struct PDFUploadView: View {
                 }
             }
             .navigationDestination(for: Class.self) { cls in
-                SyllabusUploadView(
-                    className: cls.name,
-                    classSchedule: cls.schedule,
-                    classColor: cls.color,
-                    existingClassID: cls.id,
-                    onSyncComplete: { navigationPath = NavigationPath() }
-                )
-                .environmentObject(classManager)
+                ClassEditView(cls: cls, onSyncComplete: { navigationPath = NavigationPath() })
+                    .environmentObject(classManager)
+                    .environmentObject(authManager)
             }
             .sheet(isPresented: $showAddClass) {
                 AddClassView()
@@ -274,7 +269,8 @@ struct ClassCard: View {
                 Spacer()
                 
                 // Status badge
-                if classItem.events.isEmpty {
+                switch classItem.status {
+                case .noSyllabus:
                     Text("NO SYLLABUS")
                         .font(.caption2)
                         .fontWeight(.bold)
@@ -283,7 +279,7 @@ struct ClassCard: View {
                         .padding(.vertical, 4)
                         .background(Color.orange.opacity(0.2))
                         .cornerRadius(8)
-                } else {
+                case .active:
                     Text("ACTIVE")
                         .font(.caption2)
                         .fontWeight(.bold)
@@ -291,6 +287,15 @@ struct ClassCard: View {
                         .padding(.horizontal, 8)
                         .padding(.vertical, 4)
                         .background(classItem.color.opacity(0.2))
+                        .cornerRadius(8)
+                case .inactive:
+                    Text("INACTIVE")
+                        .font(.caption2)
+                        .fontWeight(.bold)
+                        .foregroundColor(.gray)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(Color.gray.opacity(0.2))
                         .cornerRadius(8)
                 }
                 
@@ -306,7 +311,8 @@ struct ClassCard: View {
             }
             
             // Event count / upload prompt
-            if classItem.events.isEmpty {
+            switch classItem.status {
+            case .noSyllabus:
                 HStack(spacing: 4) {
                     Image(systemName: "arrow.up.doc")
                         .font(.caption)
@@ -314,8 +320,14 @@ struct ClassCard: View {
                         .font(.caption)
                 }
                 .foregroundColor(.orange.opacity(0.8))
-            } else {
-                Text("\(classItem.events.count) events synced")
+            case .active:
+                let visibleCount = classItem.events.filter { !$0.isDeletedLocally }.count
+                Text("\(visibleCount) events synced")
+                    .font(.caption)
+                    .foregroundColor(.gray)
+            case .inactive:
+                let visibleCount = classItem.events.filter { !$0.isDeletedLocally }.count
+                Text("\(visibleCount) events")
                     .font(.caption)
                     .foregroundColor(.gray)
             }
@@ -357,6 +369,9 @@ struct CalendarEvent: Codable, Identifiable {
     var colorHex: String = "007AFF"
     var status: EventStatus = .pending
     var isSyllabus: Bool = true
+    var isEdited: Bool = false
+    var googleEventId: String? = nil
+    var isDeletedLocally: Bool = false
 
     var color: Color {
         get { Color(hex: colorHex) }
@@ -364,7 +379,7 @@ struct CalendarEvent: Codable, Identifiable {
     }
 
     enum CodingKeys: String, CodingKey {
-        case id, title, date, type, description, colorHex, status, isSyllabus
+        case id, title, date, type, description, colorHex, status, isSyllabus, isEdited, googleEventId, isDeletedLocally
     }
 
     init(title: String, date: String, type: String, description: String) {
@@ -385,6 +400,9 @@ struct CalendarEvent: Codable, Identifiable {
         colorHex = try container.decodeIfPresent(String.self, forKey: .colorHex) ?? "007AFF"
         status = try container.decodeIfPresent(EventStatus.self, forKey: .status) ?? .pending
         isSyllabus = try container.decodeIfPresent(Bool.self, forKey: .isSyllabus) ?? true
+        isEdited = try container.decodeIfPresent(Bool.self, forKey: .isEdited) ?? false
+        googleEventId = try container.decodeIfPresent(String.self, forKey: .googleEventId)
+        isDeletedLocally = try container.decodeIfPresent(Bool.self, forKey: .isDeletedLocally) ?? false
     }
 }
 

--- a/Plannr/Plannr/SyllabusUploadView.swift
+++ b/Plannr/Plannr/SyllabusUploadView.swift
@@ -14,11 +14,14 @@ import PhotosUI
 struct SyllabusUploadView: View {
     @Environment(\.dismiss) var dismiss
     @EnvironmentObject var classManager: ClassManager
+    @EnvironmentObject var authManager: AuthManager
 
     let className: String
     let classSchedule: String
     let classColor: Color
     let existingClassID: UUID
+    /// Events already stored for this class — used for reconciliation on re-upload.
+    var existingEvents: [CalendarEvent] = []
     var onSyncComplete: (() -> Void)? = nil
     
     @State private var showActionSheet = false
@@ -204,6 +207,7 @@ struct SyllabusUploadView: View {
                     onSyncComplete: onSyncComplete
                 )
                 .environmentObject(classManager)
+                .environmentObject(authManager)
             }
         }
         .navigationBarTitleDisplayMode(.inline)
@@ -303,6 +307,53 @@ struct SyllabusUploadView: View {
     }
 
     
+    // MARK: - Reconcile parsed events with existing local events
+    /// Merges newly parsed events with the class's existing events.
+    /// - Matching key: lowercased title + date.
+    /// - Matched + locally edited → keep the local (edited) version, carry over googleEventId.
+    /// - Matched + not edited → use the freshly parsed version, carry over googleEventId.
+    /// - Only in new parse → add as new (no googleEventId).
+    /// - Only in existing (no match) → append to preserve them; user can delete manually.
+    func reconcileEvents(parsed: [CalendarEvent], existing: [CalendarEvent]) -> [CalendarEvent] {
+        guard !existing.isEmpty else { return parsed }
+
+        func matchKey(_ ev: CalendarEvent) -> String {
+            ev.title.lowercased().trimmingCharacters(in: .whitespaces) + "_" + ev.date
+        }
+
+        var existingByKey: [String: CalendarEvent] = [:]
+        for ev in existing where !ev.isDeletedLocally {
+            existingByKey[matchKey(ev)] = ev
+        }
+
+        var result: [CalendarEvent] = []
+        var matchedKeys = Set<String>()
+
+        for var parsedEv in parsed {
+            let key = matchKey(parsedEv)
+            if let existingEv = existingByKey[key] {
+                matchedKeys.insert(key)
+                if existingEv.isEdited {
+                    // Preserve local edits
+                    result.append(existingEv)
+                } else {
+                    // Use fresh parse but carry over the Google event ID
+                    parsedEv.googleEventId = existingEv.googleEventId
+                    result.append(parsedEv)
+                }
+            } else {
+                result.append(parsedEv)
+            }
+        }
+
+        // Append existing events that weren't matched by the new parse
+        for ev in existing where !ev.isDeletedLocally && !matchedKeys.contains(matchKey(ev)) {
+            result.append(ev)
+        }
+
+        return result
+    }
+
     // MARK: - Upload PDF
     func uploadPDF(url: URL) {
         isUploading = true
@@ -349,12 +400,16 @@ struct SyllabusUploadView: View {
                         
                         DispatchQueue.main.async {
                             let notSyllabus = jsonResponse.events.contains { $0.isSyllabus == false }
-                            if jsonResponse.events.isEmpty || notSyllabus{
+                            if jsonResponse.events.isEmpty || notSyllabus {
                                 self.uploadError = "No events were found. Please ensure you are uploading a valid course syllabus and try again."
                                 self.isUploading = false
                                 return
                             }
-                            self.parsedEvents = jsonResponse.events
+                            // Reconcile parsed events with any existing local events
+                            self.parsedEvents = self.reconcileEvents(
+                                parsed: jsonResponse.events,
+                                existing: self.existingEvents
+                            )
                             self.isUploading = false
                             self.navigateToPreview = true
                         }
@@ -578,5 +633,6 @@ struct TextEntryView: View {
             existingClassID: UUID()
         )
         .environmentObject(ClassManager())
+        .environmentObject(AuthManager())
     }
 }

--- a/backend/app.py
+++ b/backend/app.py
@@ -30,6 +30,22 @@ class CalendarEvent(BaseModel):
 class CalendarSyncRequest(BaseModel):
     events: List[CalendarEvent]
 
+
+class SyncEventRequest(BaseModel):
+    local_id: str
+    title: str
+    date: str
+    description: Optional[str] = ""
+    type: Optional[str] = "other"
+    google_event_id: Optional[str] = None
+    is_deleted: bool = False
+
+
+class CalendarClassSyncRequest(BaseModel):
+    class_name: str
+    google_calendar_id: Optional[str] = None
+    events: List[SyncEventRequest]
+
 # Load environment variables from .env file
 load_dotenv()
 
@@ -474,6 +490,136 @@ async def add_to_calendar(email: str = Query(...), request: CalendarSyncRequest 
             status_code=400,
             content={"error": f"Failed to add events to calendar: {str(e)}"}
         )
+
+
+def _find_or_create_calendar(service, class_name: str) -> str:
+    """Find a secondary calendar by name, or create one. Returns the calendar ID."""
+    calendar_list = service.calendarList().list().execute()
+    for cal in calendar_list.get('items', []):
+        if cal.get('summary') == class_name:
+            return cal['id']
+    # Not found — create a new secondary calendar
+    new_cal = service.calendars().insert(body={'summary': class_name}).execute()
+    return new_cal['id']
+
+
+def _build_google_event_body(event: SyncEventRequest) -> dict:
+    return {
+        'summary': event.title,
+        'description': event.description or '',
+        'start': {'date': event.date},
+        'end': {'date': event.date},
+    }
+
+
+@app.post('/calendar/sync', tags=['Syllabus to Calendar'])
+async def sync_class_calendar(email: str = Query(...), request: CalendarClassSyncRequest = Body(...)):
+    """
+    Idempotent sync of a class's events to a dedicated secondary Google Calendar.
+
+    - Creates the secondary calendar if it doesn't exist yet (find-or-create by name).
+    - Updates events that already have a google_event_id.
+    - Inserts new events that have no google_event_id.
+    - Deletes events marked is_deleted=True (if they have a google_event_id).
+    - Falls back to a full rebuild if incremental sync fails.
+
+    Returns the google_calendar_id and per-event mappings {local_id, google_event_id}.
+    """
+    try:
+        creds_json = fetch_user_creds(email)
+        if not creds_json:
+            return JSONResponse(status_code=401, content={"error": "User not authenticated."})
+
+        creds_data = json.loads(creds_json)
+        credentials = Credentials(
+            token=creds_data.get('token'),
+            refresh_token=creds_data.get('refresh_token'),
+            token_uri=creds_data.get('token_uri'),
+            client_id=creds_data.get('client_id'),
+            client_secret=creds_data.get('client_secret'),
+            scopes=creds_data.get('scopes')
+        )
+        service = build('calendar', 'v3', credentials=credentials)
+
+        # ── Step 1: get or create the secondary calendar ──────────────────────
+        cal_id = None
+        if request.google_calendar_id:
+            try:
+                service.calendars().get(calendarId=request.google_calendar_id).execute()
+                cal_id = request.google_calendar_id
+            except Exception:
+                # Calendar was deleted externally — fall through to find-or-create
+                pass
+        if not cal_id:
+            cal_id = _find_or_create_calendar(service, request.class_name)
+
+        # ── Step 2: incremental sync ──────────────────────────────────────────
+        synced_events = []
+        try:
+            for event in request.events:
+                if event.is_deleted:
+                    if event.google_event_id:
+                        try:
+                            service.events().delete(
+                                calendarId=cal_id, eventId=event.google_event_id
+                            ).execute()
+                        except Exception:
+                            pass  # already deleted — that's fine
+                    # deleted events are not returned in synced_events
+                elif event.google_event_id:
+                    # Update existing event
+                    updated = service.events().update(
+                        calendarId=cal_id,
+                        eventId=event.google_event_id,
+                        body=_build_google_event_body(event)
+                    ).execute()
+                    synced_events.append({"local_id": event.local_id, "google_event_id": updated['id']})
+                else:
+                    # Insert new event
+                    created = service.events().insert(
+                        calendarId=cal_id,
+                        body=_build_google_event_body(event)
+                    ).execute()
+                    synced_events.append({"local_id": event.local_id, "google_event_id": created['id']})
+
+        except Exception as incremental_err:
+            # ── Fallback: rebuild the entire calendar ─────────────────────────
+            print(f"Incremental sync failed ({incremental_err}), falling back to full rebuild.")
+            # Delete all events in the calendar
+            page_token = None
+            while True:
+                events_result = service.events().list(
+                    calendarId=cal_id, pageToken=page_token
+                ).execute()
+                for ev in events_result.get('items', []):
+                    try:
+                        service.events().delete(calendarId=cal_id, eventId=ev['id']).execute()
+                    except Exception:
+                        pass
+                page_token = events_result.get('nextPageToken')
+                if not page_token:
+                    break
+
+            synced_events = []
+            for event in request.events:
+                if event.is_deleted:
+                    continue
+                created = service.events().insert(
+                    calendarId=cal_id,
+                    body=_build_google_event_body(event)
+                ).execute()
+                synced_events.append({"local_id": event.local_id, "google_event_id": created['id']})
+
+        return JSONResponse(status_code=200, content={
+            "google_calendar_id": cal_id,
+            "synced_events": synced_events
+        })
+
+    except Exception as e:
+        print(f"Calendar sync error: {e}")
+        import traceback
+        traceback.print_exc()
+        return JSONResponse(status_code=400, content={"error": f"Sync failed: {str(e)}"})
 
 
 @app.post('/export', tags=['Export'])


### PR DESCRIPTION
## Summary

- Replaced the direct My Classes → PDF Upload navigation with a new **ClassEditView** landing page per class
- Added three **class statuses** (NO SYLLABUS / ACTIVE / INACTIVE) with visible badges on class cards
- Implemented **per-event editing and soft deletion** with unsynced-change tracking
- Overhauled Google Calendar sync to use **per-class secondary calendars** with idempotent, incremental sync (no duplicates)
- Added **PDF re-upload reconciliation** that preserves manual event edits across re-uploads
- Made the class **color picker interactive** in ClassEditView

## Changes

### iOS

**`ClassManager.swift`**
- Added `ClassStatus` enum (`NO_SYLLABUS` / `ACTIVE` / `INACTIVE`)
- Extended `Class` struct with `status`, `googleCalendarId`, `lastSynced`, `hasUnsyncedChanges`
- All new fields use `decodeIfPresent` with safe defaults for backward compatibility with existing UserDefaults data
- Fixed `Hashable` equality (`==`) to include visual fields (`colorHex`, `name`, `schedule`, `status`, `hasUnsyncedChanges`, `events.count`) so SwiftUI correctly re-renders class cards when those properties change

**`PDFUploadView.swift`**
- Extended `CalendarEvent` with `isEdited`, `googleEventId`, and `isDeletedLocally` fields
- `ClassCard` now uses `class.status` for badge display (NO SYLLABUS / ACTIVE / INACTIVE) and event count copy
- Navigation destination changed from `SyllabusUploadView` to `ClassEditView`

**`ClassEditView.swift`** *(new file)*
- Class detail page showing name, schedule, interactive color picker, status picker, and events list
- Status picker (ACTIVE / INACTIVE menu) shown when class has a syllabus; NO SYLLABUS is read-only
- Each event row shows an `[EDITED]` badge when locally modified, with Edit and Delete buttons
- Edit opens `EventEditView` sheet; sets `isEdited = true` and `hasUnsyncedChanges = true` on save
- Delete is soft (`isDeletedLocally = true`); the event is hidden from the list but sent to the backend on re-sync
- Bottom button is context-aware:
  - `hasUnsyncedChanges == true` → **"Re-sync (N) Changes"** — calls `POST /calendar/sync` with only changed/deleted events
  - Otherwise → **"Upload New PDF"** → pushes `SyllabusUploadView`
- After re-sync: clears `isEdited`/`isDeletedLocally` flags, removes soft-deleted events, stores returned `googleEventId`s, updates `lastSynced`

**`CalendarPreviewView.swift`**
- `syncToCalendar()` now calls `POST /calendar/sync` instead of `POST /calendar`
- Request sends `class_name`, `google_calendar_id` (nil on first sync), and per-event `local_id` / `google_event_id` / `is_deleted`
- Response applies returned `googleCalendarId` and per-event `googleEventId`s to the class; sets `status = .active`, `lastSynced`, `hasUnsyncedChanges = false`
- Added `CalendarSyncResponse` and `SyncedEventMapping` decodable models

**`SyllabusUploadView.swift`**
- Added `existingEvents: [CalendarEvent]` parameter for re-upload reconciliation
- `reconcileEvents(parsed:existing:)` merges parsed events with existing ones using a stable match key (`lowercased title + "_" + date`):
  - Matched + locally edited → preserve local version, carry over `googleEventId`
  - Matched + not edited → use freshly parsed version, carry over `googleEventId`
  - Only in new parse → add as new (no `googleEventId`)
  - Only in existing → keep appended (user can delete manually)

### Backend

**`app.py`**
- Added `SyncEventRequest` and `CalendarClassSyncRequest` Pydantic models
- Added `_find_or_create_calendar(service, class_name)` helper — lists all calendars and finds by name, or creates a new secondary calendar; prevents duplicate calendars
- Added `_build_google_event_body(event)` helper
- Added `POST /calendar/sync` endpoint:
  - Verifies or creates the secondary calendar for the class
  - **Incremental sync**: updates events with an existing `google_event_id`, inserts new events, deletes events marked `is_deleted=True`
  - **Fallback**: if incremental sync fails, deletes all calendar events and re-inserts (full rebuild)
  - Returns `{ google_calendar_id, synced_events: [{local_id, google_event_id}] }`

## Test Plan

- [ ] Create a new class → card shows NO SYLLABUS badge and "Tap to upload syllabus"
- [ ] Tap class → ClassEditView opens (not SyllabusUploadView directly)
- [ ] Tap "Upload New PDF" → upload flow → CalendarPreviewView → Sync → class becomes ACTIVE, secondary Google Calendar created, events have Google event IDs stored
- [ ] Back in ClassEditView, edit an event → `[EDITED]` badge appears, bottom button changes to "Re-sync (N) Changes"
- [ ] Tap Re-sync → only edited/deleted events sent; no duplicate calendar or events created
- [ ] Upload a new PDF for the same class → reconciliation preserves edited events and carries over `googleEventId`s
- [ ] Soft-delete an event and re-sync → event removed from Google Calendar
- [ ] Repeat sync with no changes → no duplicates in Google Calendar
- [ ] Change class color → color updates immediately on the My Classes card
- [ ] Set status to INACTIVE → badge updates on My Classes card
